### PR TITLE
Parse feature attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,5 @@ install(TARGETS fmecityjson DESTINATION ${FME_DEV_HOME}/plugins
                     WORLD_READ WORLD_EXECUTE)
 install(FILES fmecityjson.db DESTINATION ${FME_DEV_HOME}/formatsinfo)
 install(FILES fmecityjson.fmf DESTINATION ${FME_DEV_HOME}/metafile)
+
+#add_executable(test fmecityjson/test.cpp)

--- a/fmecityjson/SConscript
+++ b/fmecityjson/SConscript
@@ -11,7 +11,7 @@ pluginbuilder_env.Replace(LIBDIR = fme_home.Dir('fmecore'),
 pluginbuilder_env.Append(CXXFLAGS = ['--std=c++11'],
                          CCFLAGS = ['-Wall', '-Werror', '-Wno-deprecated',
                                     '-Wno-unused-variable', # remove after code is clean
-                                    '-O3', '-fvisibility=hidden'],
+                                    '-fvisibility=hidden','-O0', '-g'],
                          LIBPATH = ['$LIBDIR'],
                          LIBS = ['fmeobj'])
 

--- a/fmecityjson/SConstruct
+++ b/fmecityjson/SConstruct
@@ -1,3 +1,3 @@
 SConscript('./SConscript',
            exports={'fme_home'  : Dir('/opt/fme-desktop-2019'),
-                    'json_home' : Dir('../../../nlohmann_json')})
+                    'json_home' : Dir('../')})

--- a/fmecityjson/fmecityjsonreader.cpp
+++ b/fmecityjson/fmecityjsonreader.cpp
@@ -252,6 +252,10 @@ FME_Status FMECityJSONReader::read(IFMEFeature& feature, FME_Boolean& endOfFile)
    feature.setFeatureType(featureType.c_str());
 
    // Set feature attributes
+   // TODO: I'm setting the feature ID as an attribute here. Or is there a dedicated 'slot' in FME for this?
+   // TODO: For some reason when I add the 'fid' attribute here, the attribute is not enabled in the Table View
+   //  of Data Inspector. But all the attributes that are enabled in the Table View that are set in the for loop below.
+   feature.setAttribute("fid", objectId.c_str());
    if (not nextObject_.value()["attributes"].is_null())
    {
      for (json::iterator it = nextObject_.value().at("attributes").begin();


### PR DESCRIPTION
### Adds

+ parsing of various attribute types https://github.com/safesoftware/fme-CityJSON/blob/d278cf9cd3b5966c85224f80e49b9caa749edd6f/fmecityjson/fmecityjsonreader.cpp#L259-L300 . @hugoledoux I see that the CityJSON specs only allow strings as attribute values (https://www.cityjson.org/specs/1.0.1/#attributes) , but I think we should be a bit more forgiving. For example I for sure would want to set anything as an attribute... But arrays and objects are maybe one step too far? :-) What do you think? https://github.com/safesoftware/fme-CityJSON/blob/d278cf9cd3b5966c85224f80e49b9caa749edd6f/fmecityjson/fmecityjsonreader.cpp#L287-L291

+ the feature ID as an attribute. But for some reason whatever attribute I set here, the attribute is not enabled by default in the Table View of the Data Inspector (I have to enable the Column manually). While all the other attributes that are set in the for-loop are enabled. https://github.com/safesoftware/fme-CityJSON/blob/d278cf9cd3b5966c85224f80e49b9caa749edd6f/fmecityjson/fmecityjsonreader.cpp#L255-L258 

**EDIT**

Never mind, i figured what's the problem with missing feature ID. It was not added to the schema as an attribute.