### PR TITLE
Read files with multiple Level of Detail

### DIFF
--- a/fmecityjson.fmf
+++ b/fmecityjson.fmf
@@ -28,13 +28,13 @@ END_SOURCE_PREAMBLE
 
 SOURCE_SETTINGS
 
-GUI GROUP SOURCE_FMECITYJSON_PARAM Parameters
+GUI GROUP LOD Parameters
 
 !----------------------------------------------------------------------
 ! Specify the fields.
 !----------------------------------------------------------------------
-DEFAULT_VALUE SOURCE_FMECITYJSON_PARAM "" 
-GUI OPTIONAL TEXT SOURCE_FMECITYJSON_PARAM CityJSON Parameters:
+DEFAULT_VALUE LOD ""
+GUI OPTIONAL TEXT LOD CityJSON Level of Detail:
 
 DEFAULT_VALUE EXPOSE_ATTRS_GROUP $(EXPOSE_ATTRS_GROUP)
 -GUI DISCLOSUREGROUP EXPOSE_ATTRS_GROUP $(FORMAT_SHORT_NAME)_EXPOSE_FORMAT_ATTRS Schema Attributes

--- a/fmecityjson/fmecityjsonpriv.h
+++ b/fmecityjson/fmecityjsonpriv.h
@@ -51,8 +51,8 @@ const static char* const kMsgStartVisiting = "Starting visit to geometry type ";
 const static char* const kMsgVisiting      = "Visiting geometry type ";
 const static char* const kMsgEndVisiting   = "Finishing visit to geometry type ";
 
-const static char* const kCityJSONParamTag = "CityJSON Parameters: ";
-const static char* const kSrcCityJSONParamTag = "_SOURCE_CITYJSON_PARAM";
-const static char* const kMsgNoCityJSONParam = "No CityJSON Parameters were entered.";
+const static char* const kLodParamTag = "Level of Detail: ";
+const static char* const kSrcLodParamTag = "_LOD";
+const static char* const kMsgNoLodParam = "No Level of Detail were choosen.";
 
 #endif

--- a/fmecityjson/fmecityjsonreader.h
+++ b/fmecityjson/fmecityjsonreader.h
@@ -210,6 +210,10 @@ private:
                               const std::string &traitName,
                               const std::string &traitValue);
 
+   // Cast the geometry LoD to a string, even though the specs require a number.
+   // Because strings are easier to compare than floats (in case of extended LoD).
+   static std::string lodToString(json::object_t currentGeometry);
+
    // Data members
 
    // The value specified for the READER_TYPE in the mapping file.
@@ -247,6 +251,8 @@ private:
    json inputJSON_;
    json::iterator nextObject_;
    std::vector<std::tuple<double, double, double>> vertices_;
+   std::vector<std::string> lod_present_;
+   std::string lod_to_read_;
 
    bool schemaScanDone_;
    std::map<std::string, IFMEFeature*> schemaFeatures_;

--- a/fmecityjson/fmecityjsonreader.h
+++ b/fmecityjson/fmecityjsonreader.h
@@ -241,7 +241,7 @@ private:
 
    // The parameters value used for reading the dataset.
    // For some formats, they have no need for parameters.
-   std::string cityJsonParameters_;
+   std::string lodParam_;
 
    // -----------------------------------------------------------------------
    // Insert additional private data members here
@@ -251,8 +251,7 @@ private:
    json inputJSON_;
    json::iterator nextObject_;
    std::vector<std::tuple<double, double, double>> vertices_;
-   std::vector<std::string> lod_present_;
-   std::string lod_to_read_;
+   std::vector<std::string> lodInData_;
 
    bool schemaScanDone_;
    std::map<std::string, IFMEFeature*> schemaFeatures_;

--- a/fmecityjson/fmecityjsonreader.h
+++ b/fmecityjson/fmecityjsonreader.h
@@ -175,7 +175,7 @@ private:
    FME_Status readRaster(const std::string& fullFileName, FME_UInt32& appearanceReference, std::string readerToUse);
 
    // Parse a single Geometry of a CityObject
-   void parseCityJSONObjectGeometry(IFMEFeature& feature,
+   void parseCityObjectGeometry(IFMEFeature& feature,
                                     json::value_type &currentGeometry);
    // Parse a Multi- or CompositeSolid
    template <typename MCSolid>
@@ -188,14 +188,14 @@ private:
    void parseMultiCompositeSurface(MCSurface multiCompositeSurface, json::value_type &boundaries,
                                    json::value_type &semantics);
    // Parse a single Surface of the boundary
-   IFMEFace *parseCityJSONSurface(json::value_type surface,
+   IFMEFace *parseSurface(json::value_type surface,
                                   json::value_type semanticSurface);
 
    // Parse a MultiLineString
    void parseMultiLineString(IFMEMultiCurve *mlinestring, json::value_type &boundaries);
 
    // Parse a single Ring to an IFMELine
-   void parseCityJSONRings(std::vector<IFMELine *> *rings,
+   void parseRings(std::vector<IFMELine *> *rings,
                            json::value_type &boundary);
 
    // Parse a single LineString


### PR DESCRIPTION
The user can specify the Level of Detail as a Parameter, thus a single LoD is read at once. The user is always informed in the translation log when there are multiple LoDs in the data.

![image](https://user-images.githubusercontent.com/7190603/69426784-58eff900-0d2e-11ea-89b5-6c37b500c131.png)

If the user wants to read multiple LoD into the same workbench, then they need to create a reader per LoD, setting the lod parameter accordingly.

![image](https://user-images.githubusercontent.com/7190603/69435641-3961cc00-0d40-11ea-9ea9-c72a8db173c6.png)

In case the LoD is not specified, it defaults to the Lod of the first Geometry of the first CityObject.

![image](https://user-images.githubusercontent.com/7190603/69426906-9f455800-0d2e-11ea-9478-c6d51d88cf67.png)


https://github.com/safesoftware/fme-CityJSON/blob/b68292368f1b55550d5fcfae9f5c20fbb2c282ce/fmecityjson/fmecityjsonreader.cpp#L230-L256


This approach also means that we need to go through each Geometry already in the `open` method.
https://github.com/safesoftware/fme-CityJSON/blob/b68292368f1b55550d5fcfae9f5c20fbb2c282ce/fmecityjson/fmecityjsonreader.cpp#L211-L221

However, the advantage is that the features are always CityObjects, regardless of the LoD. Opposed to what the CityGML reader does, creating a feature for each semantic surface for LoD2 data  (see #12 ).
