### PR TITLE
Don't crash when there is no LOD in the file.

### DIFF
--- a/fmecityjson/fmecityjsonreader.cpp
+++ b/fmecityjson/fmecityjsonreader.cpp
@@ -244,8 +244,7 @@ FME_Status FMECityJSONReader::open(const char *datasetName, const IFMEStringArra
             gLogFile->logMessageString(defaultMsg.c_str(), FME_WARN);
             lodParam_ = lodInData_[0];
         }
-
-    } else {
+    } else if (lodInData_.size() == 1) {
         // In case there is only one LoD in the data, we ignore the Parameter
         // even if it is set.
         lodParam_ = lodInData_[0];


### PR DESCRIPTION
I changed the code so that it handles the "one LOD in the file case" only when there is actually one LOD in the file.

It is still not possibly doing the right thing if there are NO LOD specified in the file, but at least it does not crash anymore.  Feel free to improve the code in that area.
