### PR TITLE
Writer schema generation starting point

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,16 @@ from the menu. In the Error List pane, check that there
 are 0 errors.
 
 ## Installation Instructions
-The latest beta versions of FME now already ship with this included.  (FME 2020.0 and later)
+The latest beta versions of FME now already ship with this included.  (FME 2020.0 and later) No work is needed.
 If you wish to update FME yourself, there are several steps necessary to extend FME to include this CityJSON Format support.
 
 * The Plugin:
 **Build the CityJSON plugin, using the instructions above.  This will produce a file `cityjson.so` file on Linux and macOS (a `.dylib` will be created under macOS, but the CMake will rename it to a `.so` otherwise FME won't work), or a `cityjson.dll` file on Windows.  Copy this file into the `plugins` subdirectory where FME is installed.
+* The Metafile:
+** Copy the file `cityjson.fmf` into the `metafile` subdirectory where FME is installed.
+(The metafile contains directives that inform FME of the details about a format such as default parameters, settings, schemas and so on.)
+* The cityJSON schema files
+** visit https://github.com/cityjson/specs and download the "schemas" subdirectory, for the version of the specs you want to use.  Drop those into the FME install directory in this precise location (For the 1.0.1 version, for example):  plugins/cityjson/1.0.1/schemas
 * Restart FME
 
 ## How to debug

--- a/cityjson.fmf
+++ b/cityjson.fmf
@@ -5,7 +5,8 @@
 ! Define the format name.
 ! --------------------------------------------------------------------------------
 DEFAULT_MACRO FORMAT_SHORT_NAME CITYJSON
-SOURCE_READER CITYJSON EXPOSED_ATTRS "$($(FORMAT_SHORT_NAME)_EXPOSE_FORMAT_ATTRS)"
+SOURCE_READER CITYJSON EXPOSED_ATTRS "$($(FORMAT_SHORT_NAME)_EXPOSE_FORMAT_ATTRS)" \
+		       -CITYJSON_VERSION "$(CITYJSON_VERSION)"
 FORMAT_NAME   CITYJSON
 FORMAT_TYPE DYNAMIC
 
@@ -96,7 +97,7 @@ END_PREAMBLE
 ! --------------------------------------------------------------------------------
 ! Directive to allow dynamic reader driven fixed schemas
 ! --------------------------------------------------------------------------------
-!WORKBENCH_CANNED_SCHEMA cityjson/cityjson.sch
+WORKBENCH_CANNED_SCHEMA READ_AS_SOURCE
 
 ! ----------------------------------------------------------------------
 ! make "User Attributes" tab uneditable for writer?
@@ -106,7 +107,7 @@ END_PREAMBLE
 ! must be specified after "WORKBENCH_CANNED_SCHEMA" as fan-out does not 
 ! make sense in a fixed schema format.
 ! --------------------------------------------------------------------------------
-!WORKBENCH_NO_FEATURE_TYPE_FANOUT
+WORKBENCH_NO_FEATURE_TYPE_FANOUT
 
 ! ----------------------------------------------------------------------
 ! Note that because later on we define GEOMETRY_TYPE_FIELD fme_type

--- a/fmecityjson/fmecityjsonpriv.h
+++ b/fmecityjson/fmecityjsonpriv.h
@@ -60,5 +60,10 @@ const static char* const kSrcRemoveDuplicates = "_REMOVE_DUPLICATES";
 const static char* const kSrcCompress         = "_USE_COMPRESSION";
 const static char* const kSrcImportantDigits  = "_IMPORTANT_DIGITS";
 
+// Used when the writer is looking for schema features from the reader
+const static char* const kCityJSON_FME_DIRECTION    = "FME_DIRECTION";
+const static char* const kCityJSON_FME_DESTINATION  = "DESTINATION";
+const static char* const kCityJSON_CITYJSON_VERSION = "CITYJSON_VERSION";
+
 
 #endif

--- a/fmecityjson/fmecityjsonreader.h
+++ b/fmecityjson/fmecityjsonreader.h
@@ -168,6 +168,7 @@ private:
    // Please refer to the IFMEMappingFile documentation for more information in
    // FME_DEV_HOME/pluginbuilder/cpp/apidoc/classIFMEMappingFile.html
    void readParametersDialog();
+   bool fetchWriterDirectives(const IFMEStringArray& parameters);
 
    // -----------------------------------------------------------------------
    // Insert additional private methods here
@@ -219,6 +220,18 @@ private:
    // Because strings are easier to compare than floats (in case of extended LoD).
    static std::string lodToString(json currentGeometry);
 
+   // -----------------------------------------------------------------------
+   // If the reader is being used as a "helper" to the writer, to gather
+   // schema feature definitions, this will look in the official CityJSON specs
+   // and pull out the correct schema information.
+   FME_Status scrapeSchemaFeaturesForWriter();
+
+   // -----------------------------------------------------------------------
+   // Helper function to recursively add nested attribute types to a schema feature.
+   void addAttributeNamesAndTypes(IFMEFeature& schemaFeature,
+                                  const std::string& attributeName,
+                                  json attributeValue) const;
+
    // Data members
 
    // The value specified for the READER_TYPE in the mapping file.
@@ -261,11 +274,15 @@ private:
    std::vector<std::string> lodInData_;
 
    bool schemaScanDone_;
-   bool schemaScaneDoneMeta_;
+   bool schemaScanDoneMeta_;
    std::map<std::string, IFMEFeature*> schemaFeatures_;
 
    IFMEString* textureCoordUName_;
    IFMEString* textureCoordVName_;
+
+   // These are when the reader is used as a "helper" to the writer
+   bool writerHelperMode_;
+   std::string writerSchemaVersion_;
 };
 
 #endif


### PR DESCRIPTION
works toward issue #38 

This just lays down the framework for scraping schema information from official specs dynamically when generating a workspace with a CityJSON writer.